### PR TITLE
fix(gwtw): strip 'origin/@' prefix to match display format

### DIFF
--- a/git-worktree.plugin.zsh
+++ b/git-worktree.plugin.zsh
@@ -660,7 +660,7 @@ function gwtw() {
         return 1
       fi
 
-      branch_name=$(echo "$selection" | sed 's/^  origin\///' | sed 's/^  //')
+      branch_name=$(echo "$selection" | sed 's/^  origin\/@//' | sed 's/^  //')
     else
       echo "Usage: gwtw <branch-name> [base-branch]"
       echo "Example: gwtw travis/plat-934-non-deterministic-behavior"


### PR DESCRIPTION
I noticed that checking out branches using `gwtw` and the fuzzy finder prefixed all created branches with `@`, causing a mismatch between the local and the remote branch. This means simply using `git push` did not work, because the remote branch name had to be specified each time. Removing `@` fixes this.