### PR TITLE
Do not track base branch on remote when creating new local branch

### DIFF
--- a/git-worktree.plugin.zsh
+++ b/git-worktree.plugin.zsh
@@ -508,14 +508,14 @@ function gwta() {
       (cd "$repo_root" && git fetch origin "$base_branch" 2>/dev/null)
       if git show-ref --verify --quiet "refs/remotes/origin/$base_branch"; then
         echo "🌱 Creating new branch '$branch_name' from origin/$base_branch"
-        _gwt_add_worktree add -b "$branch_name" "$branch_name" "origin/$base_branch" && wt_ok=true
+        _gwt_add_worktree add --no-track -b "$branch_name" "$branch_name" "origin/$base_branch" && wt_ok=true
       else
         echo "⚠️  Remote branch 'origin/$base_branch' not found, using local '$base_branch'"
-        _gwt_add_worktree add -b "$branch_name" "$branch_name" "$base_branch" && wt_ok=true
+        _gwt_add_worktree add --no-track -b "$branch_name" "$branch_name" "$base_branch" && wt_ok=true
       fi
     else
       echo "🌱 Creating new branch '$branch_name' from $base_branch"
-      _gwt_add_worktree add -b "$branch_name" "$branch_name" "$base_branch" && wt_ok=true
+      _gwt_add_worktree add --no-track -b "$branch_name" "$branch_name" "$base_branch" && wt_ok=true
     fi
   elif git show-ref --verify --quiet "refs/heads/$branch_name"; then
     echo "🌿 Checking out existing branch '$branch_name'"
@@ -731,10 +731,10 @@ function gwtw() {
 
     echo "🌱 Creating new branch '$branch_name' from origin/$base_branch..."
     if git show-ref --verify --quiet "refs/remotes/origin/$base_branch"; then
-      _gwt_add_worktree add -b "$branch_name" "$branch_name" "origin/$base_branch" && wt_ok=true
+      _gwt_add_worktree add --no-track -b "$branch_name" "$branch_name" "origin/$base_branch" && wt_ok=true
     else
       echo "⚠️  Remote branch 'origin/$base_branch' not found, using local '$base_branch'"
-      _gwt_add_worktree add -b "$branch_name" "$branch_name" "$base_branch" && wt_ok=true
+      _gwt_add_worktree add --no-track -b "$branch_name" "$branch_name" "$base_branch" && wt_ok=true
     fi
   fi
 


### PR DESCRIPTION
I noticed that creating a new local branch using `gwtw` would automatically track the base branch on the remote, which I found unexpected. This PR prevents adding a tracking branch for newly created local branches.

Before:
```
gwtw test  
📡 Fetching from origin...
🌱 Creating new branch 'test' from origin/master...
Preparing worktree (new branch 'test')
branch 'test' set up to track 'origin/master'.
```

After:
```
gwtw test         
📡 Fetching from origin...
🌱 Creating new branch 'test' from origin/master...
Preparing worktree (new branch 'test')
HEAD is now at 2dfa5322e blablabla
✅ Worktree ready at: /path/to/worktree
```